### PR TITLE
Add conversation ID to query API

### DIFF
--- a/rag_backend/main.py
+++ b/rag_backend/main.py
@@ -110,13 +110,15 @@ async def delete_conversation(conversation_id: str):
 @app.post("/query", response_model=QueryResponse)
 async def query(request: QueryRequest):
     """
-    Process a query using the RAG system, with optional conversation memory.
-    
+    Process a query using the RAG system, optionally leveraging conversation
+    memory.
+
     Args:
-        request: The query request containing the query and parameters
-    
+        request: The query request containing the question and optional
+            ``conversation_id`` for maintaining context.
+
     Returns:
-        The generated answer and retrieved documents
+        The generated answer and retrieved documents.
     """
     global rag_chain
     

--- a/rag_backend/models/schema.py
+++ b/rag_backend/models/schema.py
@@ -2,11 +2,20 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 
 class QueryRequest(BaseModel):
-    """Request model for querying the RAG system."""
+    """Request model for querying the RAG system.
+
+    Attributes:
+        query: The query string.
+        k: Number of documents to retrieve.
+        rerank: Whether to rerank the retrieved documents.
+        rerank_top_k: Number of top documents to keep after reranking.
+        conversation_id: Optional ID of the conversation for contextual memory.
+    """
     query: str = Field(..., description="The query string")
     k: int = Field(4, description="Number of documents to retrieve")
     rerank: bool = Field(True, description="Whether to rerank the retrieved documents")
     rerank_top_k: Optional[int] = Field(None, description="Number of top documents to keep after reranking")
+    conversation_id: Optional[str] = Field(None, description="ID of the conversation for contextual memory")
 
 class DocumentResponse(BaseModel):
     """Response model for a retrieved document."""

--- a/src/App.js
+++ b/src/App.js
@@ -166,7 +166,16 @@ const ChatPage = () => {
     'Какой лучший фреймворк для React?'
   ]);
   const [isHovering, setIsHovering] = useState(false);
+  const [conversationId, setConversationId] = useState(null);
 
+  useEffect(() => {
+    const storedId = localStorage.getItem('conversation_id');
+    if (storedId) {
+      setConversationId(storedId);
+    }
+  }, []);
+
+  // Send a message and include the conversation ID if it exists
   const handleSendMessage = async () => {
       if (inputValue.trim()) {
         const newMessage = {
@@ -181,7 +190,7 @@ const ChatPage = () => {
         setInputValue('');
 
         try {
-          const response = await sendMessage(inputValue, history);
+          const response = await sendMessage(inputValue, history, conversationId);
           const botResponse = {
             id: Date.now() + 1,
             text: response.answer || "Ошибка получения ответа от сервера.",

--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -1,8 +1,15 @@
-export async function sendMessage(question, history = []) {
+/**
+ * Send a chat message to the backend.
+ *
+ * @param {string} question - User question
+ * @param {Array} history - Previous chat history
+ * @param {string|null} conversationId - Optional conversation identifier
+ */
+export async function sendMessage(question, history = [], conversationId = null) {
     const res = await fetch('http://localhost:8000/query', { // <-- changed from '/chat'
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: question, history })
+      body: JSON.stringify({ query: question, history, conversation_id: conversationId })
     });
     return res.json();
 }


### PR DESCRIPTION
## Summary
- support `conversation_id` in `QueryRequest`
- document optional conversation ID in backend schema and query route
- send `conversation_id` from frontend when available

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2217ede48329bbed9adb99c43380